### PR TITLE
Fix type errors

### DIFF
--- a/src/MethodReflectionFactory.php
+++ b/src/MethodReflectionFactory.php
@@ -8,6 +8,7 @@ use PHPStan\PhpDoc\Tag\ParamTag;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\Php\PhpMethodReflectionFactory;
+use PHPStan\Reflection\Php\NativeBuiltinMethodReflection;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Type;
 
@@ -80,6 +81,8 @@ final class MethodReflectionFactory
 
         if ($methodWrapper) {
             $methodReflection = new $methodWrapper($methodReflection);
+        } else {
+            $methodReflection = new NativeBuiltinMethodReflection($methodReflection);
         }
 
         return $this->methodReflectionFactory->create(

--- a/src/ReflectionMethodAlwaysStatic.php
+++ b/src/ReflectionMethodAlwaysStatic.php
@@ -2,19 +2,11 @@
 
 namespace Weebly\PHPStan\Laravel;
 
-final class ReflectionMethodAlwaysStatic extends \ReflectionMethod
-{
-    /**
-     * @param \ReflectionMethod $reflectionMethod
-     *
-     * @throws \ReflectionException
-     */
-    public function __construct(\ReflectionMethod $reflectionMethod)
-    {
-        parent::__construct($reflectionMethod->getDeclaringClass()->getName(), $reflectionMethod->getName());
-    }
+use PHPStan\Reflection\Php\NativeBuiltinMethodReflection;
 
-    public function isStatic()
+final class ReflectionMethodAlwaysStatic extends NativeBuiltinMethodReflection
+{
+    public function isStatic(): bool
     {
         return true;
     }


### PR DESCRIPTION
Starting from branch: feature/laravel-57-for-phpstan10.1
I got type errors in the phpstan-laravel it self.

The fixes are:
**Fix type error for facades because of wrong implementation.**

> Type error: Argument 3 passed to class@anonymous::create() must implement interface PHPStan\Reflection\Php\BuiltinMethodReflection, instance of Weebly\PHPStan\Laravel\ReflectionMethodAlwaysStatic given, called in laravel5.5\vendor\weebly\phpstan-laravel\src\MethodReflectionFactory.php on line 94
> 

Caused by: Mail::send(...);

**Fix type error for static create of model.**

> Type error: Argument 3 passed to class@anonymous::create() must implement interface PHPStan\Reflection\Php\BuiltinMethodReflection, instance of ReflectionMethod given, called in laravel5.5\vendor\weebly\phpstan-laravel\src\MethodReflectionFactory.php on line 94
>

Caused by: Model::firstOrNew([...]);
or: Illuminate\Database\Query\Builder::firstOrNew([...]);

Now all the Tests passed correct. I hope this will help your PR to be completed and accepted.